### PR TITLE
Spring Security로 로그인 인증 구현, 회원 가입 로직 구현, AuthenticationPrincipal로 Use…

### DIFF
--- a/recipe/src/main/java/com/recipe/controller/AuthController.java
+++ b/recipe/src/main/java/com/recipe/controller/AuthController.java
@@ -57,7 +57,7 @@ public class AuthController {
             @RequestParam String nickname){
 
         boolean isAvailable = authService.checkExistsNickname(nickname);
-        String message = isAvailable ? "사용 가능한 닉네임입니다." : "현재 사용중인 닉네임입니다.";
+        String message = isAvailable ?  "현재 사용중인 닉네임입니다." : "사용 가능한 닉네임입니다.";
         NicknameAvailabilityResponse response = NicknameAvailabilityResponse.builder()
                 .isAvailable(isAvailable)
                 .message(message)

--- a/recipe/src/main/java/com/recipe/controller/RecipeController.java
+++ b/recipe/src/main/java/com/recipe/controller/RecipeController.java
@@ -3,6 +3,7 @@ package com.recipe.controller;
 import com.recipe.domain.dto.PageRequestDTO;
 import com.recipe.domain.dto.Recipe.RecipeResponseDTO;
 import com.recipe.domain.dto.SortBy;
+import com.recipe.domain.dto.autho.CustomerDetails;
 import com.recipe.service.RecipeService;
 import com.recipe.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "레시피", description = "레시피에 대한 API 명세서")
@@ -62,10 +64,12 @@ public class RecipeController {
                     @ApiResponse(responseCode = "404", description = "레시피 Not Found")
             })
     @GetMapping("/recipes/{recipeId}")
-    public ResponseEntity<Void> detailsRecipe(@PathVariable("recipeId") Long recipeId) {
+    public ResponseEntity<Void> detailsRecipe(@PathVariable("recipeId") Long recipeId,
+                                              @AuthenticationPrincipal CustomerDetails customer) {
 
-        //해당 레시피 단건 조회
-        recipeService.findOneRecipe(recipeId);
+        Long userId = customer.getUserId();
+        log.info("UserId: {}", userId);
+        recipeService.findOneRecipe(recipeId, userId);
 
         return ResponseEntity.ok().build();
     }

--- a/recipe/src/main/java/com/recipe/controller/advice/ControllerAdvice.java
+++ b/recipe/src/main/java/com/recipe/controller/advice/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.recipe.controller.advice;
 
 import com.recipe.exceptions.recipe.RecipeException;
+import com.recipe.exceptions.user.UserException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +17,26 @@ import java.util.Map;
 public class ControllerAdvice {
     @ExceptionHandler(RecipeException.class)
     public ResponseEntity<Map<String, String>>RecipeEx(RecipeException ex){
+        HttpStatus status = HttpStatus.resolve(ex.getCode());
+        if(status == null){
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+
         Map<String ,String> errors =Map.of("message", ex.getMessage());
-        return new ResponseEntity<>(errors, HttpStatus.NOT_FOUND);
+        return ResponseEntity.status(status).body(errors);
+    }
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<Map<String, String>>UserEx(UserException ex){
+        HttpStatus status =HttpStatus.resolve(ex.getCode());
+        if (status == null) {
+            //log
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+
+        Map<String, String> errors = new HashMap<>();
+        errors.put("message", ex.getMessage());
+        return ResponseEntity.status(status).body(errors);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/recipe/src/main/java/com/recipe/domain/dto/user/UserLoginRequestDTO.java
+++ b/recipe/src/main/java/com/recipe/domain/dto/user/UserLoginRequestDTO.java
@@ -15,12 +15,9 @@ import java.time.LocalDate;
 public class UserLoginRequestDTO {
 
     @NotBlank(message = "아이디를 입력하세요")
-//    @Size()
     private String id;
 
     @NotBlank(message = "비밀번호를 입력하세요")
-//    @Size()
-//    @Pattern()
     private String password;
 
 }

--- a/recipe/src/main/java/com/recipe/domain/dto/user/UserRegisterRequestDTO.java
+++ b/recipe/src/main/java/com/recipe/domain/dto/user/UserRegisterRequestDTO.java
@@ -1,10 +1,7 @@
 package com.recipe.domain.dto.user;
 
 import com.recipe.domain.entity.enums.Gender;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,19 +11,18 @@ import java.time.LocalDate;
 @Getter
 public class UserRegisterRequestDTO {
     @NotBlank(message = "아이디를 입력하세요")
-//    @Size()
+    @Size(min = 8, max = 16, message = "아이디는 최소 8자 최대 16자입니다.")
     private String id;
 
     @NotBlank(message = "비밀번호를 입력하세요")
-//    @Size()
-//    @Pattern()
+    @Size(min = 8, max = 32, message = "비밀번호는 최소 8자 최대 32자입니다.")
+//    @Pattern(regexp = "(?=.*[A-Z])(?=.*[a-z](?=.*)")
     private String password;
 
     @NotBlank(message = "이름을 입력하세요")
 //    @Size
     private String name;
 
-    //닉네임 중복 확인 구현
     @NotBlank(message = "닉네임을 입력하세요")
 //    @Size
     private String nickname;
@@ -35,7 +31,6 @@ public class UserRegisterRequestDTO {
     @Email(message = "옳바른 이메일 형식이 아닙니다.")
     private String email;
 
-    //생년월일을 받는 것이 좋을 것 같다 인증 정보등..
     @NotNull(message = "생년월일은 필수 입니다.")
     @Past(message = "생년월일은 현재를 넘길 수 없습니다.")
     private LocalDate birth;

--- a/recipe/src/main/java/com/recipe/domain/entity/BaseEntityTime.java
+++ b/recipe/src/main/java/com/recipe/domain/entity/BaseEntityTime.java
@@ -26,4 +26,8 @@ public class BaseEntityTime {
     @LastModifiedDate
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm:ss")
     private LocalDateTime modifiedDate;
+
+    public void updateModifiedDate(){
+        modifiedDate = LocalDateTime.now();
+    }
 }

--- a/recipe/src/main/java/com/recipe/domain/entity/UserReferences.java
+++ b/recipe/src/main/java/com/recipe/domain/entity/UserReferences.java
@@ -12,14 +12,14 @@ import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "USERREFERENCE")
+@Table(name = "USER_REFERENCE")
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @ToString
-public class UserReferences {
+public class UserReferences extends BaseEntityTime{
     @Id
     @GeneratedValue
     @Column(name = "PREFERENCE_ID")
@@ -41,11 +41,4 @@ public class UserReferences {
     private PreferenceType preference;
 
     //RATING
-
-    @Column(name = "PREFERENCE_DATE")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy:MM:dd HH:mm:ss")
-    @DateTimeFormat(pattern = "yyyy:MM:dd HH:mm:ss")
-    @CreatedDate
-    @LastModifiedDate
-    private LocalDateTime date;
 }

--- a/recipe/src/main/java/com/recipe/exceptions/user/UserException.java
+++ b/recipe/src/main/java/com/recipe/exceptions/user/UserException.java
@@ -1,5 +1,8 @@
 package com.recipe.exceptions.user;
 
+import lombok.Getter;
+
+@Getter
 public class UserException extends RuntimeException {
     String message;
     int code;
@@ -8,5 +11,9 @@ public class UserException extends RuntimeException {
         super(message);
         this.message = message;
         this.code = code;
+    }
+
+    public void changeMessage(String message){
+        this.message = message;
     }
 }

--- a/recipe/src/main/java/com/recipe/exceptions/user/UserExceptions.java
+++ b/recipe/src/main/java/com/recipe/exceptions/user/UserExceptions.java
@@ -4,15 +4,22 @@ import lombok.Getter;
 
 @Getter
 public enum UserExceptions {
-    NOT_FOUND("NOT_FOUND", 404);
+    NOT_FOUND("NOT_FOUND", 404),
+    CONFLICT("CONFLICT", 409);
 
-    private UserException userException;
+    private String message;
+    private int code;
 
     UserExceptions(String message, int code) {
-        userException = new UserException(message, code);
+        this.message = message;
+        this.code = code;
     }
 
     public UserException getUserException() {
-        return userException;
+        return new UserException(message, code);
+    }
+
+    public UserException getUserException(String changeMessage) {
+        return new UserException(changeMessage, code);
     }
 }

--- a/recipe/src/main/java/com/recipe/repository/UserReferencesRepository.java
+++ b/recipe/src/main/java/com/recipe/repository/UserReferencesRepository.java
@@ -4,7 +4,9 @@ import com.recipe.domain.entity.UserReferences;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserReferencesRepository extends JpaRepository<UserReferences, Long> {
-
+    public Optional<UserReferences>  findByUser_UserIdAndRecipe_RcpSno(Long userId, Long rcpSno);
 }

--- a/recipe/src/main/java/com/recipe/service/RecipeService.java
+++ b/recipe/src/main/java/com/recipe/service/RecipeService.java
@@ -2,6 +2,7 @@ package com.recipe.service;
 
 import com.recipe.domain.dto.Recipe.RecipeResponseDTO;
 import com.recipe.domain.entity.Recipe;
+import com.recipe.domain.entity.User;
 import com.recipe.exceptions.recipe.RecipeExceptions;
 import com.recipe.repository.RecipeRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class RecipeService {
 
     private final RecipeRepository recipeRepository;
     private final UserReferencesService referenceService;
+    private final UserService userService;
 
     @Transactional
     public Page<RecipeResponseDTO> readRecipePage(Pageable pageable) {
@@ -34,7 +36,8 @@ public class RecipeService {
         return recipePage.map(RecipeResponseDTO::fromEntity);
     }
 
-    public RecipeResponseDTO findOneRecipe(Long recipeId) {
+    @Transactional
+    public RecipeResponseDTO findOneRecipe(Long recipeId, Long userId) {
         log.info("Service findOneRecipe");
 
         Recipe findRecipe = recipeRepository.findById(recipeId).orElseThrow(
@@ -42,9 +45,7 @@ public class RecipeService {
         );
 
         //UserReference에 View 반영
-//        referenceService.
-        //UserReference에 조회 및 반영하기 위한 USER_ID도 필요
-
+        referenceService.userRecipeView(findRecipe, userId);
 
         return RecipeResponseDTO.fromEntity(findRecipe);
     }

--- a/recipe/src/main/java/com/recipe/service/UserReferencesService.java
+++ b/recipe/src/main/java/com/recipe/service/UserReferencesService.java
@@ -1,6 +1,9 @@
 package com.recipe.service;
 
+import com.recipe.domain.entity.Recipe;
 import com.recipe.domain.entity.User;
+import com.recipe.domain.entity.UserReferences;
+import com.recipe.domain.entity.enums.PreferenceType;
 import com.recipe.exceptions.user.UserExceptions;
 import com.recipe.repository.UserReferencesRepository;
 import com.recipe.repository.UserRepository;
@@ -8,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Log4j2
@@ -18,10 +23,31 @@ public class UserReferencesService {
     private final UserReferencesRepository referenceRepository;
     private final UserRepository userRepository;
 
-    public void userRecipeView(Long recipeId, Long userId) {
+    @Transactional
+    public void userRecipeView(Recipe recipe, Long userId) {
         User findUser = userRepository.findById(userId).orElseThrow(
                 () -> UserExceptions.NOT_FOUND.getUserException()
         );
 
+        Optional<UserReferences> findRef =
+                referenceRepository.findByUser_UserIdAndRecipe_RcpSno(userId, recipe.getRcpSno());
+
+        if(findRef.isPresent()) {
+            log.info("끄아아아아아아아아!");
+            //VIEW라면 날짜 업데이트 or LIKE라면 X(LIKE가 더 높은 레벨이라 생각하여 바꾸지 않는다.)
+            if(findRef.get().getPreference() ==  PreferenceType.VIEW) {
+                //Modified는 JpaAuditing이 있지만, DirtyChecking에 해당되지 않아 직접 바꿨습니다.
+                findRef.get().updateModifiedDate();
+            }
+        }else{
+            UserReferences references = UserReferences.builder()
+                    .user(findUser)
+                    .recipe(recipe)
+                    .preference(PreferenceType.VIEW)
+                    .build();
+            log.info("세이브 됨!!!!!!!!!!");
+            referenceRepository.save(references);
+
+        }
     }
 }

--- a/recipe/src/main/java/com/recipe/service/UserService.java
+++ b/recipe/src/main/java/com/recipe/service/UserService.java
@@ -1,0 +1,19 @@
+package com.recipe.service;
+
+import com.recipe.domain.entity.User;
+import com.recipe.exceptions.user.UserExceptions;
+import com.recipe.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User findByUser(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> UserExceptions.NOT_FOUND.getUserException());
+    }
+}


### PR DESCRIPTION
# Spring Security && JWT
- 요청을 보낸 사용자가 회원인지  Filter에서인증하기 위해 사용
 - RestAPI는 Stateless 상태로 서버에서 회원에 데이터를 저장할 수 없다. ACCESS TOKEN과 REFRESH TOKEN으로 인증
 - 사용자 PK 값을 직접 받지 않고 @AuthenticationPrincipal를 사용하여 SecurityContextHolder에 해당되는 Principal를 추출합니다.
 - Principal은 Spring Security의 User 객체를 상속 받아 CustomerDetails 클래스를 생성하여 userId를 반환합니다.
 - 로그인 시 AccessToken, RefreshToken과 각각의 만료 시간을 반환합니다.